### PR TITLE
Replace my_bool with int because my_bool no longer exists in the MySQL headers.

### DIFF
--- a/lib_mysqludf_skeleton.c
+++ b/lib_mysqludf_skeleton.c
@@ -30,7 +30,7 @@
 #ifdef	__cplusplus
 extern "C" {
 #endif
-	DLLEXP my_bool lib_mysqludf_skeleton_info_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+	DLLEXP int lib_mysqludf_skeleton_info_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
 	DLLEXP void lib_mysqludf_skeleton_info_deinit(UDF_INIT *initid);
 	/* For functions that return STRING or DECIMAL */ 
 	DLLEXP char *lib_mysqludf_skeleton_info(UDF_INIT *initid, UDF_ARGS *args, char *result, unsigned long *length, char *is_null, char *error);
@@ -54,7 +54,7 @@ extern "C" {
  * lib_mysqludf_skeleton_info()
  */
 
-my_bool lib_mysqludf_skeleton_info_init(UDF_INIT *initid, UDF_ARGS *args, char *message)
+int lib_mysqludf_skeleton_info_init(UDF_INIT *initid, UDF_ARGS *args, char *message)
 {
 	return 0;
 }


### PR DESCRIPTION
Thank you for making this repository available.

I replaced my_bool with int in lib_mysqludf_skeleton.c. 

See https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html#mysqld-8-0-1-compiling